### PR TITLE
Clean up ConnectivityHelper code

### DIFF
--- a/app/src/main/java/com/example/explorandes/utils/ConnectivityHelper.kt
+++ b/app/src/main/java/com/example/explorandes/utils/ConnectivityHelper.kt
@@ -12,6 +12,7 @@ class ConnectivityHelper(private val context: Context) {
     
     private val TAG = "ConnectivityHelper"
     
+    
     /**
      * Verifica si hay una conexión a Internet disponible
      */

--- a/app/src/main/java/com/example/explorandes/utils/ConnectivityHelper.kt
+++ b/app/src/main/java/com/example/explorandes/utils/ConnectivityHelper.kt
@@ -16,7 +16,6 @@ class ConnectivityHelper(private val context: Context) {
      * Verifica si hay una conexión a Internet disponible
      */
     fun isInternetAvailable(): Boolean {
-        // Fix: Use ConnectivityManager from Android, not our ConnectivityHelper
         val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
         val network = connectivityManager?.activeNetwork ?: return false
         val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false


### PR DESCRIPTION
Remove unnecessary comments and whitespace in the ConnectivityHelper class for improved code clarity.